### PR TITLE
fix issue 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,15 @@
 
 You'll be writing your code in `lib/my_collect.rb`. 
 
-Let's say we are writing an app to help teachers manage their students. Our teacher has a list of students:
+You are writing a method that behaves just like the real `#collect` method. It should take in an argument of a collection, iterate over that collection using a `while` loop, and execute the code in the block you call it with for each element in the collection (use the `yield` keyword). It should return the modified collection. 
+
+Your `#my_collect` method, therefore, should not care the contents of the code block that it is invoked with. For example, let's say we are writing an app to help teachers manage their students. Our teacher has a list of students:
 
 ```ruby
 ["Tim Jones", "Tom Smith", "Jim Campagno"]
 ```
 
 The list includes the first and last name of each student, but our teacher needs to collect a list of *just their first names*. 
-
-
-You are writing a method that behaves just like the real `#collect` method. It should take in an argument of a collection, iterate over that collection using a `while` loop, and execute the code in the block you call it with for each element in the collection (use the `yield` keyword). It should return the modified collection. 
 
 So, if our teacher uses `#my_collect` to collect the first name of his students, it should work like this: 
 
@@ -34,5 +33,20 @@ Should return:
 ```ruby
 ["Tim", "Tom", "Jim"]
 ```
+
+What if your method was being invoked with a totally different collection and a totally different code block? For example, let's say your `#my_collect` method is given an argument of a list of programming languages, and passed a block that capitalizes the elements yeiled to it. 
+
+```ruby
+collection = ['ruby', 'javascript', 'python', 'objective-c']
+my_collect(collection) do |lang|
+  lang.uppercase
+end
+
+# => ["RUBY", "JAVASCRIPT", "PYTHON", "OBJECTIVE-C"]
+```
+
+Your method should behave the same way––iterating over the given collection and passing each member to the given block––regardless of the content of the collection or the nature of the block.
+
+
 Make sure to run bundle install before running your tests.
 <p data-visibility='hidden'>View <a href='https://learn.co/lessons/my-collect' title='My #collect'>My #collect</a> on Learn.co and start learning to code for free.</p>

--- a/spec/my_collect_spec.rb
+++ b/spec/my_collect_spec.rb
@@ -1,5 +1,6 @@
 describe "my_collect" do
   let(:languages) { ['ruby', 'javascript', 'python', 'objective-c'] }
+  let(:students) { ['Tim Jones', 'Tom Smith', 'Sophie Johnson', 'Antoin Miller'] }
 
   it "can handle an empty collection" do
     empty_array = []
@@ -10,13 +11,13 @@ describe "my_collect" do
     expect(counter).to eq(0)
   end
 
-  it "yields the correct element" do
+  it "yields the correct element from a given collection, in this case languages" do
     my_collect(languages) do |language|
       expect(language).to_not eq(nil)
     end
   end
 
-  it "returns a new collection" do
+  it "returns a new collection of appropriately modified elements, in this case capitalized languages" do
     expect(my_collect(languages) do |language|
       language.upcase
     end).to eq(["RUBY", "JAVASCRIPT", "PYTHON", "OBJECTIVE-C"])
@@ -27,5 +28,24 @@ describe "my_collect" do
       language.upcase
     end
     expect(languages).to eq(['ruby', 'javascript', 'python', 'objective-c'])
+  end
+
+  it "yields the correct element from the given collection, in this case students" do
+    my_collect(students) do |student|
+      expect(student).to_not eq(nil)
+    end
+  end
+
+  it "returns a new collection of appropriately modified elements, in this case student first names" do
+    expect(my_collect(students) do |language|
+      student.split(" ").first
+    end).to eq(["Tim", "Tom", "Sophie", "Antoin"])
+  end
+
+  it 'does not modify the original collection' do
+    my_collect(students) do |language|
+      language.upcase
+    end
+    expect(students).to eq(['Tim Jones', 'Tom Smith', 'Sophie Johnson', 'Antoin Miller'])
   end
 end


### PR DESCRIPTION
readme uses student collection as example, test suite uses languages. method should be abstract--yield members of any given collection to any given block. clarified this in readme and added tests for another case--both langauges behavior and students